### PR TITLE
Feature/fix snackbar initial config

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -2,12 +2,19 @@
 
 ## Content table <!-- omit from toc -->
 - [Versions](#versions)
+  - [1.0.0-preview.5](#100-preview5)
   - [1.0.0-preview.4](#100-preview4)
   - [1.0.0-preview.3](#100-preview3)
   - [1.0.0-preview.2](#100-preview2)
   - [1.0.0-preview.1](#100-preview1)
 
 ## Versions
+### [1.0.0-preview.5](https://www.nuget.org/packages/HorusStudio.Maui.MaterialDesignControls/1.0.0-preview.5)
+* Bug: Outlined inputs not rendered when overriding global style
+* Bug: Tint color fixed on MaterialIconButton
+* Bug: ConfigureSnackbar throw NullReferenceException if BackgroundColor was not set
+* [iOS] Bug: Leading and trailing icons width on Snackbar
+ 
 ### [1.0.0-preview.4](https://www.nuget.org/packages/HorusStudio.Maui.MaterialDesignControls/1.0.0-preview.4)
 * [Android] Bug #49: MaterialFloatingButton does not appear.
 

--- a/docs/Controls/horusstudio.maui.materialdesigncontrols.materialiconbutton.md
+++ b/docs/Controls/horusstudio.maui.materialdesigncontrols.materialiconbutton.md
@@ -195,7 +195,7 @@ Remarks:
 
 ### <a id="properties-icontintcolor"/>**IconTintColor**
 
-Gets or sets the  for the text of the button.
+Gets or sets the  for the icon of the button.
  This is a bindable property.
 
 Property type: [Color](https://learn.microsoft.com/en-us/dotnet/api/microsoft.maui.graphics.color)<br>
@@ -210,6 +210,14 @@ Allows you to display a bitmap image on the Button.
 Property type: [ImageSource](https://learn.microsoft.com/en-us/dotnet/api/microsoft.maui.controls.imagesource)<br>
 
 Remarks: For more options have a look at .
+
+<br>
+
+### <a id="properties-internalicontintcolor"/>**InternalIconTintColor**
+
+This property is for internal use by the control. The IconTintColor property should be used instead.
+
+Property type: [Color](https://learn.microsoft.com/en-us/dotnet/api/microsoft.maui.graphics.color)<br>
 
 <br>
 
@@ -242,15 +250,6 @@ Property type: [Shadow](https://learn.microsoft.com/en-us/dotnet/api/microsoft.m
 
 <br>
 
-### <a id="properties-tintcolor"/>**TintColor**
-
-Gets or sets the  for the text of the button.
- This is a bindable property.
-
-Property type: [Color](https://learn.microsoft.com/en-us/dotnet/api/microsoft.maui.graphics.color)<br>
-
-<br>
-
 ### <a id="properties-type"/>**Type**
 
 Gets or sets the button type according to MaterialIconButtonType enum.
@@ -270,7 +269,7 @@ Default value: MaterialIconButtonType.Filled
 
 <br>
 
-### <a id="properties-usetintcolor"/>**UseTintColor**
+### <a id="properties-useicontintcolor"/>**UseIconTintColor**
 
 Gets or sets if button should use tint color.
  The default value is true.

--- a/docs/Controls/horusstudio.maui.materialdesigncontrols.materialsnackbarconfig.md
+++ b/docs/Controls/horusstudio.maui.materialdesigncontrols.materialsnackbarconfig.md
@@ -307,4 +307,3 @@ Default value: null
 ## Known issues and pending features
 
 * Add FontFamily configuration
- * [iOS] When sizes are too big, last element on UI gets cropped

--- a/nuget.props
+++ b/nuget.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup Condition=" $(MSBuildProjectName.Equals('HorusStudio.Maui.MaterialDesignControls')) ">
     <PackageId>HorusStudio.Maui.MaterialDesignControls</PackageId>
-    <Version>1.0.0-preview.4</Version>
+    <Version>1.0.0-preview.5</Version>
     <Authors>Horus Studio and contributors</Authors>
     <Company>Horus Studio</Company>
     <Title>Material Design Controls for .NET MAUI</Title>
@@ -15,7 +15,10 @@
     <PackageTags>dotnet-maui;dotnet;maui;cross-platform;android;ios;macos;maccatalyst;materialdesign;ui</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
-      - [Android] Bug #49: MaterialFloatingButton does not appear
+      - Bug: Outlined inputs not rendered when overriding global style
+      - Bug: Tint color fixed on MaterialIconButton
+      - Bug: ConfigureSnackbar throw NullReferenceException if BackgroundColor was not set
+      - [iOS] Bug: Leading and trailing icons width on Snackbar
     </PackageReleaseNotes>
 
     <PackageOutputPath>$(MSBuildThisFileDirectory)Artifacts</PackageOutputPath>

--- a/src/HorusStudio.Maui.MaterialDesignControls/Builder/MaterialAnimationOptions.cs
+++ b/src/HorusStudio.Maui.MaterialDesignControls/Builder/MaterialAnimationOptions.cs
@@ -1,5 +1,6 @@
 namespace HorusStudio.Maui.MaterialDesignControls;
 
+[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
 public sealed class MaterialAnimationOptions
 {
     public double? Parameter { get; set; }

--- a/src/HorusStudio.Maui.MaterialDesignControls/Builder/MaterialDesignControls.cs
+++ b/src/HorusStudio.Maui.MaterialDesignControls/Builder/MaterialDesignControls.cs
@@ -5,6 +5,7 @@ namespace HorusStudio.Maui.MaterialDesignControls;
 /// <summary>
 /// Material Design Controls initializer class
 /// </summary>
+[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
 public static class MaterialDesignControls
 {
     private static readonly HashSet<InitialTask> InitialTasks = [];

--- a/src/HorusStudio.Maui.MaterialDesignControls/Builder/MaterialDesignControlsBuilder.cs
+++ b/src/HorusStudio.Maui.MaterialDesignControls/Builder/MaterialDesignControlsBuilder.cs
@@ -10,8 +10,10 @@ namespace HorusStudio.Maui.MaterialDesignControls;
 /// Material Design Controls builder.
 /// </summary>
 /// <param name="AppBuilder">MAUI application builder.</param>
+[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
 public sealed record MaterialDesignControlsBuilder(MauiAppBuilder AppBuilder);
 
+[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
 public static class MaterialDesignControlsBuilderExtensions
 {
     /// <summary>

--- a/src/HorusStudio.Maui.MaterialDesignControls/Builder/MaterialElevationOptions.cs
+++ b/src/HorusStudio.Maui.MaterialDesignControls/Builder/MaterialElevationOptions.cs
@@ -1,5 +1,6 @@
 ﻿namespace HorusStudio.Maui.MaterialDesignControls;
 
+[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
 public sealed class MaterialElevationOptions
 {
     public Shadow? Level1 { get; set; }

--- a/src/HorusStudio.Maui.MaterialDesignControls/Builder/MaterialFont.cs
+++ b/src/HorusStudio.Maui.MaterialDesignControls/Builder/MaterialFont.cs
@@ -1,3 +1,4 @@
 namespace HorusStudio.Maui.MaterialDesignControls;
 
+[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
 internal sealed record MaterialFont(string FileName, string? Alias);

--- a/src/HorusStudio.Maui.MaterialDesignControls/Builder/MaterialFontOptions.cs
+++ b/src/HorusStudio.Maui.MaterialDesignControls/Builder/MaterialFontOptions.cs
@@ -1,3 +1,4 @@
 namespace HorusStudio.Maui.MaterialDesignControls;
 
+[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
 public sealed record MaterialFontOptions(string Regular, string Medium, string Default);

--- a/src/HorusStudio.Maui.MaterialDesignControls/Builder/MaterialFormatOptions.cs
+++ b/src/HorusStudio.Maui.MaterialDesignControls/Builder/MaterialFormatOptions.cs
@@ -1,5 +1,6 @@
 namespace HorusStudio.Maui.MaterialDesignControls;
 
+[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
 public sealed class MaterialFormatOptions
 {
     public string? DateFormat { get; set; }

--- a/src/HorusStudio.Maui.MaterialDesignControls/Builder/MaterialIconOptions.cs
+++ b/src/HorusStudio.Maui.MaterialDesignControls/Builder/MaterialIconOptions.cs
@@ -1,5 +1,6 @@
 namespace HorusStudio.Maui.MaterialDesignControls;
 
+[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
 public sealed class MaterialIconOptions
 {
     public ImageSource? Error { get; set; }

--- a/src/HorusStudio.Maui.MaterialDesignControls/Builder/MaterialSizeOptions.cs
+++ b/src/HorusStudio.Maui.MaterialDesignControls/Builder/MaterialSizeOptions.cs
@@ -1,5 +1,6 @@
 namespace HorusStudio.Maui.MaterialDesignControls;
 
+[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
 public sealed class MaterialSizeOptions
 {
     public double? DisplayLarge { get; set; }

--- a/src/HorusStudio.Maui.MaterialDesignControls/Builder/MaterialSnackbarOptions.cs
+++ b/src/HorusStudio.Maui.MaterialDesignControls/Builder/MaterialSnackbarOptions.cs
@@ -1,5 +1,6 @@
 namespace HorusStudio.Maui.MaterialDesignControls;
 
+[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
 public sealed class MaterialSnackbarOptions
 {
     public Thickness? DefaultMargin { get; set; }

--- a/src/HorusStudio.Maui.MaterialDesignControls/Builder/MaterialTheme.cs
+++ b/src/HorusStudio.Maui.MaterialDesignControls/Builder/MaterialTheme.cs
@@ -1,5 +1,6 @@
 namespace HorusStudio.Maui.MaterialDesignControls;
 
+[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
 public sealed class MaterialTheme
 {
     public Color? Primary { get; set; }

--- a/src/HorusStudio.Maui.MaterialDesignControls/Controls/DatePicker/DateSelectedEventArgs.cs
+++ b/src/HorusStudio.Maui.MaterialDesignControls/Controls/DatePicker/DateSelectedEventArgs.cs
@@ -1,5 +1,6 @@
 namespace HorusStudio.Maui.MaterialDesignControls;
 
+[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
 public class DateSelectedEventArgs : EventArgs
 {
     public DateTime? OldValue { get; private set; }

--- a/src/HorusStudio.Maui.MaterialDesignControls/Controls/InputBase/MaterialInputBase.xaml.cs
+++ b/src/HorusStudio.Maui.MaterialDesignControls/Controls/InputBase/MaterialInputBase.xaml.cs
@@ -36,6 +36,7 @@ public enum MaterialInputTypeStates
     OutlinedErrorFocused
 }
 
+[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
 public abstract partial class MaterialInputBase
 {
     #region Attributes

--- a/src/HorusStudio.Maui.MaterialDesignControls/Controls/Picker/CustomPickerHandler.Android.cs
+++ b/src/HorusStudio.Maui.MaterialDesignControls/Controls/Picker/CustomPickerHandler.Android.cs
@@ -69,7 +69,7 @@ partial class CustomPickerHandler
     }
 }
 
-public class CustomWindowCallback : Java.Lang.Object, Android.Views.Window.ICallback
+class CustomWindowCallback : Java.Lang.Object, Android.Views.Window.ICallback
 {
     private readonly Android.Views.Window.ICallback _originalCallback;
     private readonly System.Action _pickerUnfocus;

--- a/src/HorusStudio.Maui.MaterialDesignControls/Controls/Snackbar/MaterialSnackbarBuilder.Android.cs
+++ b/src/HorusStudio.Maui.MaterialDesignControls/Controls/Snackbar/MaterialSnackbarBuilder.Android.cs
@@ -11,7 +11,7 @@ using Color = Microsoft.Maui.Graphics.Color;
 
 namespace HorusStudio.Maui.MaterialDesignControls;
 
-public class MaterialSnackbarBuilder : Snackbar.Callback
+class MaterialSnackbarBuilder : Snackbar.Callback
 {
     #region Constants
     

--- a/src/HorusStudio.Maui.MaterialDesignControls/Controls/Snackbar/MaterialSnackbarBuilder.MaciOS.cs
+++ b/src/HorusStudio.Maui.MaterialDesignControls/Controls/Snackbar/MaterialSnackbarBuilder.MaciOS.cs
@@ -7,7 +7,7 @@ using HorusStudio.Maui.MaterialDesignControls.Utils;
 
 namespace HorusStudio.Maui.MaterialDesignControls;
 
-public class MaterialSnackbarBuilder : UIView
+class MaterialSnackbarBuilder : UIView
 {
     #region Constants
     

--- a/src/HorusStudio.Maui.MaterialDesignControls/Controls/Snackbar/MaterialSnackbarConfig.cs
+++ b/src/HorusStudio.Maui.MaterialDesignControls/Controls/Snackbar/MaterialSnackbarConfig.cs
@@ -39,7 +39,6 @@ public enum MaterialSnackbarPosition
 /// </example>
 /// <todoList>
 /// * Add FontFamily configuration
-/// * [iOS] When sizes are too big, last element on UI gets cropped
 /// </todoList>
 [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
 public class MaterialSnackbarConfig(string message)

--- a/src/HorusStudio.Maui.MaterialDesignControls/Controls/Snackbar/MaterialSnackbarConfig.cs
+++ b/src/HorusStudio.Maui.MaterialDesignControls/Controls/Snackbar/MaterialSnackbarConfig.cs
@@ -41,9 +41,24 @@ public enum MaterialSnackbarPosition
 /// * Add FontFamily configuration
 /// * [iOS] When sizes are too big, last element on UI gets cropped
 /// </todoList>
+[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
 public class MaterialSnackbarConfig(string message)
 {
     #region Default values
+    
+    private static readonly Func<Color> DefaultBackgroundColorBuilder = () => new AppThemeBindingExtension { Light = MaterialLightTheme.InverseSurface, Dark = MaterialDarkTheme.InverseSurface }.GetValueForCurrentTheme<Color>();
+    private static readonly Func<Color> DefaultTextColorBuilder = () => new AppThemeBindingExtension { Light = MaterialLightTheme.InverseOnSurface, Dark = MaterialDarkTheme.InverseOnSurface }.GetValueForCurrentTheme<Color>();
+    private static readonly Func<double> DefaultFontSizeBuilder = () => MaterialFontSize.BodyMedium;
+    private static readonly Func<Color> DefaultActionColorBuilder = () => new AppThemeBindingExtension { Light = MaterialLightTheme.InversePrimary, Dark = MaterialDarkTheme.InversePrimary }.GetValueForCurrentTheme<Color>();
+    private static readonly Func<double> DefaultActionSizeBuilder = () => MaterialFontSize.BodyMedium;
+    private static readonly Func<Color> DefaultIconColorBuilder = () => new AppThemeBindingExtension { Light = MaterialLightTheme.InverseOnSurface, Dark = MaterialDarkTheme.InverseOnSurface }.GetValueForCurrentTheme<Color>();
+
+    private static Color? _defaultBackgroundColor;
+    private static Color? _defaultTextColor;
+    private static double? _defaultFontSize;
+    private static Color? _defaultActionColor;
+    private static double? _defaultActionSize;
+    private static Color? _defaultIconColor;
     
     /// <summary>
     /// Margin to be applied by default to every <see cref="MaterialSnackbar"/> that doesn't set one
@@ -74,14 +89,18 @@ public class MaterialSnackbarConfig(string message)
     /// </summary>
     /// <default>8</default>
     public static float DefaultCornerRadius { get; set; } = 8f;
-    
+
     /// <summary>
     /// Background <see cref="Color"/> to be applied by default to every <see cref="MaterialSnackbar"/> that doesn't set one
     /// </summary>
     /// <default>
     /// Light: <see cref="MaterialLightTheme.InverseSurface">MaterialLightTheme.InverseSurface</see> - Dark: <see cref="MaterialDarkTheme.InverseSurface">MaterialDarkTheme.InverseSurface</see>
     /// </default>
-    public static Color DefaultBackgroundColor { get; set; } = new AppThemeBindingExtension { Light = MaterialLightTheme.InverseSurface, Dark = MaterialDarkTheme.InverseSurface }.GetValueForCurrentTheme<Color>();
+    public static Color DefaultBackgroundColor
+    {
+        get => _defaultBackgroundColor ?? DefaultBackgroundColorBuilder();
+        set => _defaultBackgroundColor = value;
+    }
     
     /// <summary>
     /// Text <see cref="Color"/> to be applied by default to every <see cref="MaterialSnackbar"/> that doesn't set one
@@ -89,7 +108,11 @@ public class MaterialSnackbarConfig(string message)
     /// <default>
     /// Light: <see cref="MaterialLightTheme.InverseOnSurface">MaterialLightTheme.InverseOnSurface</see> - Dark: <see cref="MaterialDarkTheme.InverseOnSurface">MaterialDarkTheme.InverseOnSurface</see>
     /// </default>
-    public static Color DefaultTextColor { get; set; } = new AppThemeBindingExtension { Light = MaterialLightTheme.InverseOnSurface, Dark = MaterialDarkTheme.InverseOnSurface }.GetValueForCurrentTheme<Color>();
+    public static Color DefaultTextColor
+    {
+        get => _defaultTextColor ?? DefaultTextColorBuilder();
+        set => _defaultTextColor = value;
+    }
     
     /// <summary>
     /// Text font size to be applied by default to every <see cref="MaterialSnackbar"/> that doesn't set one
@@ -97,7 +120,11 @@ public class MaterialSnackbarConfig(string message)
     /// <default>
     /// <see cref="MaterialFontSize.BodyMedium">MaterialFontSize.BodyMedium</see>
     /// </default>
-    public static double DefaultFontSize { get; set; } = MaterialFontSize.BodyMedium;
+    public static double DefaultFontSize 
+    {
+        get => _defaultFontSize ?? DefaultFontSizeBuilder();
+        set => _defaultFontSize = value;
+    }
     
     /// <summary>
     /// Action text <see cref="Color"/> to be applied by default to every <see cref="MaterialSnackbar"/> that doesn't set one
@@ -105,7 +132,11 @@ public class MaterialSnackbarConfig(string message)
     /// <default>
     /// Light: <see cref="MaterialLightTheme.InversePrimary">MaterialLightTheme.InversePrimary</see> - Dark: <see cref="MaterialDarkTheme.InversePrimary">MaterialDarkTheme.InversePrimary</see>
     /// </default>
-    public static Color DefaultActionColor { get; set; } = new AppThemeBindingExtension { Light = MaterialLightTheme.InversePrimary, Dark = MaterialDarkTheme.InversePrimary }.GetValueForCurrentTheme<Color>();
+    public static Color DefaultActionColor 
+    {
+        get => _defaultActionColor ?? DefaultActionColorBuilder();
+        set => _defaultActionColor = value;
+    }
     
     /// <summary>
     /// Action font size to be applied by default to every <see cref="MaterialSnackbar"/> that doesn't set one
@@ -113,7 +144,11 @@ public class MaterialSnackbarConfig(string message)
     /// <default>
     /// <see cref="MaterialFontSize.BodyMedium">MaterialFontSize.BodyMedium</see>
     /// </default>
-    public static double DefaultActionSize { get; set; } = MaterialFontSize.BodyMedium;
+    public static double DefaultActionSize 
+    {
+        get => _defaultActionSize ?? DefaultActionSizeBuilder();
+        set => _defaultActionSize = value;
+    }
     
     /// <summary>
     /// Icon <see cref="Color"/> to be applied by default to every <see cref="MaterialSnackbar"/> that doesn't set one
@@ -121,7 +156,11 @@ public class MaterialSnackbarConfig(string message)
     /// <default>
     /// Light: <see cref="MaterialLightTheme.InverseOnSurface">MaterialLightTheme.InverseOnSurface</see> - Dark: <see cref="MaterialDarkTheme.InverseOnSurface">MaterialDarkTheme.InverseOnSurface</see>
     /// </default>
-    public static Color DefaultIconColor { get; set; } = new AppThemeBindingExtension { Light = MaterialLightTheme.InverseOnSurface, Dark = MaterialDarkTheme.InverseOnSurface }.GetValueForCurrentTheme<Color>();
+    public static Color DefaultIconColor 
+    {
+        get => _defaultIconColor ?? DefaultIconColorBuilder();
+        set => _defaultIconColor = value;
+    }
     
     /// <summary>
     /// Duration applied by default to every <see cref="MaterialSnackbar"/> that doesn't set one
@@ -304,6 +343,7 @@ public class MaterialSnackbarConfig(string message)
     /// </summary>
     /// <param name="source">Icon <see cref="ImageSource"/></param>
     /// <param name="action">Action to be executed when icon is tapped</param>
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
     public class IconConfig(ImageSource source, Action? action = null) : BaseActionConfig(action)
     {
         /// <summary>
@@ -329,6 +369,7 @@ public class MaterialSnackbarConfig(string message)
     /// </summary>
     /// <param name="text">Text for action button</param>
     /// <param name="action">Action to be executed when button is tapped</param>
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
     public class ActionConfig(string text, Action action) : BaseActionConfig(action)
     {
         /// <summary>
@@ -354,6 +395,7 @@ public class MaterialSnackbarConfig(string message)
     /// <summary>
     /// User-defined base configuration for an actions on <see cref="MaterialSnackbar"/>
     /// </summary>
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
     public abstract class BaseActionConfig
     {
         private Color? _color;

--- a/src/HorusStudio.Maui.MaterialDesignControls/Controls/TimePicker/TimeSelectedEventArgs.cs
+++ b/src/HorusStudio.Maui.MaterialDesignControls/Controls/TimePicker/TimeSelectedEventArgs.cs
@@ -1,5 +1,6 @@
 namespace HorusStudio.Maui.MaterialDesignControls;
 
+[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
 public class TimeSelectedEventArgs : EventArgs
 {
     public TimeSpan? OldValue { get; private set; }


### PR DESCRIPTION
* Bug: Outlined inputs not rendered when overriding global style
* Bug: Tint color fixed on MaterialIconButton
* Bug: ConfigureSnackbar throw NullReferenceException if BackgroundColor was not set
* [iOS] Bug: Leading and trailing icons width on Snackbar